### PR TITLE
Allow the runner group to be defined as part of the runner registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ runner_org: no
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_hostname }}"
 
+# Runner group to control which runners will be used (applies to enterprise instances only)
+runner_group: "Build"
+
 # Labels to apply to the runner
 runner_labels: []
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -108,7 +108,7 @@
 
 - name: Register runner (if new installation) for enterprise
   command: "{{ runner_dir }}/./config.sh --url {{ github_url }}/enterprises/{{ github_owner | default(github_account) }} \
-            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended"
+            --token {{ registration.json.token }} --name {{ runner_name }} {{ runner_group|quote if runner_group is defined else '' }} --labels {{ runner_labels | join(',') }} --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become: yes


### PR DESCRIPTION
Runner groups can be specified for Github enterprises only.

The runner is placed in the default group if one is not specified.